### PR TITLE
Use kebab-case version of `is-approx`

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -7,74 +7,74 @@ plan 33;
 {
     my $cp = Math::ChebyshevPolynomial.new(:domain(-1..1), :c((42)));
     isa-ok $cp, Math::ChebyshevPolynomial, ".new makes a proper object";
-    is_approx $cp.evaluate(0), 21, "Constant is correctly boring";
-    is_approx $cp.evaluate(1/2), 21, "Constant is still correctly boring";
+    is-approx $cp.evaluate(0), 21, "Constant is correctly boring";
+    is-approx $cp.evaluate(1/2), 21, "Constant is still correctly boring";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.new(:domain(-1..1), :c((42, 2)));
-    is_approx $cp.evaluate(0), 21, "Linear 0 is correct";
-    is_approx $cp.evaluate(1/2), 22, "Linear 1/2 is correct";
-    is_approx $cp.evaluate(-1/2), 20, "Linear -1/2 is correct";
+    is-approx $cp.evaluate(0), 21, "Linear 0 is correct";
+    is-approx $cp.evaluate(1/2), 22, "Linear 1/2 is correct";
+    is-approx $cp.evaluate(-1/2), 20, "Linear -1/2 is correct";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.new(:domain(-1..1), :c((42, 2, 3)));
-    is_approx $cp.evaluate(0), 18, "Quadratic 0 is correct";
-    is_approx $cp.evaluate(1/2), 21 + 1 - 3 / 2, "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(-1/2), 21 - 1 - 3 / 2, "Quadratic -1/2 is correct";
+    is-approx $cp.evaluate(0), 18, "Quadratic 0 is correct";
+    is-approx $cp.evaluate(1/2), 21 + 1 - 3 / 2, "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(-1/2), 21 - 1 - 3 / 2, "Quadratic -1/2 is correct";
 }
 
 {
     my &f = -> $x { 3 * $x * $x + 2 * $x + 1 };
     my $cp = Math::ChebyshevPolynomial.approximate(-1..1, 4, &f);
     isa-ok $cp, Math::ChebyshevPolynomial, ".approximate makes a proper object";
-    is_approx $cp.evaluate(0), &f(0), "Quadratic 0 is correct";
-    is_approx $cp.evaluate(1/2), &f(1/2), "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(-1/2), &f(-1/2), "Quadratic -1/2 is correct";
+    is-approx $cp.evaluate(0), &f(0), "Quadratic 0 is correct";
+    is-approx $cp.evaluate(1/2), &f(1/2), "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(-1/2), &f(-1/2), "Quadratic -1/2 is correct";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.approximate(-1..1, 10, &cos);
     isa-ok $cp, Math::ChebyshevPolynomial, ".approximate makes a proper object";
     say $cp.c;
-    is_approx $cp.evaluate(0), cos(0), "Quadratic 0 is correct";
-    is_approx $cp.evaluate(1/2), cos(1/2), "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(-1/2), cos(-1/2), "Quadratic -1/2 is correct";
+    is-approx $cp.evaluate(0), cos(0), "Quadratic 0 is correct";
+    is-approx $cp.evaluate(1/2), cos(1/2), "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(-1/2), cos(-1/2), "Quadratic -1/2 is correct";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.approximate(-1..1, 10, &cos).derivative;
     isa-ok $cp, Math::ChebyshevPolynomial, ".derivative makes a proper object";
     say $cp.c;
-    is_approx $cp.evaluate(0), -sin(0), "Quadratic 0 is correct";
-    is_approx $cp.evaluate(1/2), -sin(1/2), "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(-1/2), -sin(-1/2), "Quadratic -1/2 is correct";
+    is-approx $cp.evaluate(0), -sin(0), abs_tol => 1e-6, desc => "Quadratic 0 is correct";
+    is-approx $cp.evaluate(1/2), -sin(1/2), "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(-1/2), -sin(-1/2), "Quadratic -1/2 is correct";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.approximate(-1..1, 10, &cos).derivative.derivative;
     isa-ok $cp, Math::ChebyshevPolynomial, ".derivative makes a proper object";
     say $cp.c;
-    is_approx $cp.evaluate(0), -cos(0), "Quadratic 0 is correct";
-    is_approx $cp.evaluate(1/2), -cos(1/2), "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(-1/2), -cos(-1/2), "Quadratic -1/2 is correct";
+    is-approx $cp.evaluate(0), -cos(0), "Quadratic 0 is correct";
+    is-approx $cp.evaluate(1/2), -cos(1/2), "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(-1/2), -cos(-1/2), "Quadratic -1/2 is correct";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.approximate(1/4..3/4, 10, &cos);
     isa-ok $cp, Math::ChebyshevPolynomial, ".approximate makes a proper object";
     say $cp.c;
-    is_approx $cp.evaluate(1/4), cos(1/4), "Quadratic 1/4 is correct";
-    is_approx $cp.evaluate(1/2), cos(1/2), "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(3/4), cos(3/4), "Quadratic 3/4 is correct";
+    is-approx $cp.evaluate(1/4), cos(1/4), "Quadratic 1/4 is correct";
+    is-approx $cp.evaluate(1/2), cos(1/2), "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(3/4), cos(3/4), "Quadratic 3/4 is correct";
 }
 
 {
     my $cp = Math::ChebyshevPolynomial.approximate(1/4..3/4, 10, &cos).derivative;
     isa-ok $cp, Math::ChebyshevPolynomial, ".derivative makes a proper object";
     say $cp.c;
-    is_approx $cp.evaluate(1/4), -sin(1/4), "Quadratic 1/4 is correct";
-    is_approx $cp.evaluate(1/2), -sin(1/2), "Quadratic 1/2 is correct";
-    is_approx $cp.evaluate(3/4), -sin(3/4), "Quadratic 3/4 is correct";
+    is-approx $cp.evaluate(1/4), -sin(1/4), "Quadratic 1/4 is correct";
+    is-approx $cp.evaluate(1/2), -sin(1/2), "Quadratic 1/2 is correct";
+    is-approx $cp.evaluate(3/4), -sin(3/4), "Quadratic 3/4 is correct";
 }


### PR DESCRIPTION
The underscore version of the `is-approx` test function will be removed in
the upcoming initial release of Perl 6, hence the necessecity for this
change.

Note that in one of the comparisons, the `abs_tol` argument needed to be
used, since the comparison was around zero, which is notorious for being
hard to compare with.  Adding the absolute tolerance to the (default)
relative tolerance, allows the comparison to work in this particular case.
