### PR TITLE
Update is-approx call to current Test.pm API

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -47,7 +47,7 @@ plan 33;
     my $cp = Math::ChebyshevPolynomial.approximate(-1..1, 10, &cos).derivative;
     isa-ok $cp, Math::ChebyshevPolynomial, ".derivative makes a proper object";
     say $cp.c;
-    is-approx $cp.evaluate(0), -sin(0), abs_tol => 1e-6, desc => "Quadratic 0 is correct";
+    is-approx $cp.evaluate(0), -sin(0), 1e-6, "Quadratic 0 is correct";
     is-approx $cp.evaluate(1/2), -sin(1/2), "Quadratic 1/2 is correct";
     is-approx $cp.evaluate(-1/2), -sin(-1/2), "Quadratic -1/2 is correct";
 }


### PR DESCRIPTION
The `is-approx` function now no longer takes `abs_tol` as a named argument,
it is expected as a positional argument.  `desc` is also no longer a named
argument.  This change now gets the test suite to pass again.
